### PR TITLE
fix:input view keyboard move when not at bottom

### DIFF
--- a/SOMessaging/SOMessageInputView.m
+++ b/SOMessaging/SOMessageInputView.m
@@ -297,8 +297,10 @@
 - (void)handleKeyboardWillShowNote:(NSNotification *)notification
 {
     CGRect keyboardRect = [[notification.userInfo objectForKey:UIKeyboardFrameEndUserInfoKey] CGRectValue];
+    CGRect windowRect = self.window.bounds;
     if (UIInterfaceOrientationIsLandscape([UIApplication sharedApplication].statusBarOrientation)) {
         keyboardRect = CGRectMake(keyboardRect.origin.x, keyboardRect.origin.y, MAX(keyboardRect.size.width,keyboardRect.size.height), MIN(keyboardRect.size.width,keyboardRect.size.height));
+        windowRect = CGRectMake(windowRect.origin.x, windowRect.origin.y, MAX(windowRect.size.width,windowRect.size.height), MIN(windowRect.size.width,windowRect.size.height));
     }
     
     keyboardFrame = keyboardRect;
@@ -310,7 +312,8 @@
     keyboardDuration = duration;
     
     CGRect frame = self.frame;
-    frame.origin.y = self.superview.bounds.size.height - frame.size.height - keyboardRect.size.height;
+    // calculate the absolute ending point (based on the window rather than superview, which could be contained in a tab bar or tool bar)
+    frame.origin.y = windowRect.size.height - frame.size.height - keyboardRect.size.height;
     initialInputViewPosYWhenKeyboardIsShown = frame.origin.y;
     
     [self adjustTableViewWithCurve:YES scrollsToBottom:YES];


### PR DESCRIPTION
If the input view is not at the very bottom on the screen (for example, if it is above a tool bar or in a tab view controller), the keyboard moves up and leaves a blank space the height of the tab/tool bar:
![screen shot 2014-07-07 at 12 14 53 pm](https://cloud.githubusercontent.com/assets/840118/3499039/9429d5a8-05fb-11e4-86a6-e5a5eddf52e2.png)
![screen shot 2014-07-07 at 12 15 11 pm](https://cloud.githubusercontent.com/assets/840118/3498988/21897972-05fb-11e4-8912-6b2c09f45444.png)
This change calculates the absolute ending location based on the window rather than the superview so that the input view always ends just above the keyboard.

The animation is not perfect, however, as the input view moves a different distance than the keyboard when not at the bottom.  I could not find an easy way to synchronize the animation; to be pixel perfect, the animation for the input view would have to start when the keyboard reaches the bottom of the input view.
