### PR TITLE
fix:move input view based on delta to handle all embedding cases

### DIFF
--- a/SOMessaging/SOMessageInputView.m
+++ b/SOMessaging/SOMessageInputView.m
@@ -271,7 +271,11 @@
     if (frm.size.height < self.textMaxHeight) {
         if (frm.size.height < self.textInitialHeight) {
             frm.size.height = self.textInitialHeight;
-            frm.origin.y = self.superview.bounds.size.height - frm.size.height - keyboardFrame.size.height;
+            // adjust to global coordinates to compensate for the chat view being contained in a tab bar
+            // and navigation controller
+            CGRect globalFrame = [self.superview convertRect:frm toView:nil];
+            delta = (self.window.bounds.size.height - frm.size.height - keyboardFrame.size.height) - globalFrame.origin.y;
+            frm.origin.y += delta;
         }
         
         [UIView animateWithDuration:0.3 animations:^{


### PR DESCRIPTION
The previous change to adjust for the chat view controller being in a tab view controller does not work if the chat view controller is contained in its own navigation controller (it still shows a blank space the height of the tab bar).

This fix properly moves the input view regardless of how the chat view controller is embedded (i.e. it works with the current demo app with no embedding, it work if the chat view controller is embedded in a tab view controller with or without a navigation controller containing the chat view controller, and it works if the chat view controller is embedded in a navigation view controller).

Sorry I didn't catch this issue with the previous enhancement.
