### PR TITLE
Fix iOS 8 UIResponder bug: rename inputView to messageInputView

### DIFF
--- a/DemoProject/SOSimpleChatDemo/Sources/Controllers/Type3VC.m
+++ b/DemoProject/SOSimpleChatDemo/Sources/Controllers/Type3VC.m
@@ -32,11 +32,11 @@
 //--------------------------------------------------
 //         Customizing input view
 //--------------------------------------------------
-    self.inputView.textInitialHeight = 45;
-    self.inputView.textView.font = [UIFont systemFontOfSize:17];
+    self.messageInputView.textInitialHeight = 45;
+    self.messageInputView.textView.font = [UIFont systemFontOfSize:17];
     
     // Apply changes
-    [self.inputView adjustInputView];
+    [self.messageInputView adjustInputView];
 //--------------------------------------------------
     
     [self loadMessages];

--- a/SOMessaging/SOMessagingViewController.h
+++ b/SOMessaging/SOMessagingViewController.h
@@ -35,7 +35,7 @@
 
 #pragma mark - Properties
 @property (strong, nonatomic) UITableView *tableView;
-@property (strong, nonatomic) SOMessageInputView *inputView;
+@property (strong, nonatomic) SOMessageInputView *messageInputView;
 
 #pragma mark - Methods
 /**

--- a/SOMessaging/SOMessagingViewController.m
+++ b/SOMessaging/SOMessagingViewController.m
@@ -70,11 +70,11 @@
     
     [self.view addSubview:self.tableView];
     
-    self.inputView = [[SOMessageInputView alloc] init];
-    self.inputView.delegate = self;
-    self.inputView.tableView = self.tableView;
-    [self.view addSubview:self.inputView];
-    [self.inputView adjustPosition];
+    self.messageInputView = [[SOMessageInputView alloc] init];
+    self.messageInputView.delegate = self;
+    self.messageInputView.tableView = self.tableView;
+    [self.view addSubview:self.messageInputView];
+    [self.messageInputView adjustPosition];
 }
 
 #pragma mark - View lifecicle
@@ -116,7 +116,7 @@
 // This code will work only if this vc hasn't navigation controller
 - (BOOL)shouldAutorotate
 {
-    if (self.inputView.viewIsDragging) {
+    if (self.messageInputView.viewIsDragging) {
         return NO;
     }
     return YES;


### PR DESCRIPTION
If you'll try to call `becomeFirstResponder` for cell on iOS 8, you get crash. This commit fix it.
